### PR TITLE
Fast inference

### DIFF
--- a/butterfly/benchmark_linear.py
+++ b/butterfly/benchmark_linear.py
@@ -1,0 +1,43 @@
+import os, sys
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, project_root)
+
+import torch
+
+from butterfly import Butterfly
+from butterfly.butterfly_multiply import butterfly_mult, butterfly_mult_untied, butterfly_mult_untied_svd, butterfly_mult_factors, butterfly_mult_inplace
+from factor_multiply import butterfly_multiply_untied_batch
+
+# single threaded inference
+torch.set_num_threads(1)
+
+import time
+nsteps = 1000
+
+batch_size = 16
+n = 512
+# create multiple models so the weights aren't already loaded in the cache
+L = [torch.nn.Linear(n, n, bias=False) for _ in range(nsteps)]
+x = torch.randn(batch_size, n, requires_grad=True)
+B_untied = [Butterfly(n, n, bias=False, tied_weight=False) for _ in range(nsteps)]
+twiddle_untied = [B_untied[i].twiddle for i in range(nsteps)]
+
+grad = torch.randn_like(x)
+
+start = time.perf_counter()
+for i in range(nsteps):
+    output = butterfly_mult_untied(twiddle_untied[i], x.unsqueeze(1))
+end = time.perf_counter()
+print(f'Butterfly mult untied forward: {end - start}s')
+
+start = time.perf_counter()
+for i in range(nsteps):
+    output = butterfly_multiply_untied_batch(twiddle_untied[i], x.unsqueeze(1), True)
+end = time.perf_counter()
+print(f'Butterfly mult untied batch forward: {end - start}s')
+
+start = time.perf_counter()
+for i in range(nsteps):
+    output = L[i](x)
+end = time.perf_counter()
+print(f'Gemm forward: {end - start}s')

--- a/butterfly/benchmark_linear.py
+++ b/butterfly/benchmark_linear.py
@@ -6,7 +6,7 @@ import torch
 
 from butterfly import Butterfly
 from butterfly.butterfly_multiply import butterfly_mult, butterfly_mult_untied, butterfly_mult_untied_svd, butterfly_mult_factors, butterfly_mult_inplace
-from factor_multiply import butterfly_multiply_untied_batch, butterfly_multiply_untied_eval
+from factor_multiply import butterfly_multiply_untied, butterfly_multiply_untied_eval
 
 # single threaded inference
 torch.set_num_threads(1)
@@ -14,115 +14,83 @@ torch.set_num_threads(1)
 import time
 nsteps = 2000
 
-# batch_size = 22
-# in_ = 512
-# out_ = 512
-
-def run(in_, out_, batch_size, verbose=False):
+# includes most of the python overhead of calling classes (for instance, minus reshaping the input)
+def run(in_, out_, batch_size):
     # create multiple models so the weights aren't already loaded in the cache
     L = [torch.nn.Linear(in_, out_, bias=False) for _ in range(nsteps)]
-    # sequence length
-    x = torch.randn(batch_size, 1, in_, requires_grad=False)
     B_untied = [Butterfly(in_, out_, bias=False, tied_weight=False) for _ in range(nsteps)]
     twiddle_untied = [B_untied[i].twiddle for i in range(nsteps)]
+    x = torch.randn(batch_size, in_, requires_grad=False)
 
     bfly_start = time.perf_counter()
     for i in range(nsteps):
-        output = B_untied[i](x.contiguous().view(-1, x.shape[2])).view(x.shape[0], x.shape[1], -1)
+        output = B_untied[i](x)
     bfly_end = time.perf_counter()
-    bfly_time = bfly_end - bfly_start
-    print(bfly_time)
+    bfly_time_train = bfly_end - bfly_start
+    print(f'Butterfly Training Forward: {bfly_time_train}')
 
     B_untied = [i.eval() for i in B_untied]
     bfly_start = time.perf_counter()
     for i in range(nsteps):
-        output = B_untied[i](x.contiguous().view(-1, x.shape[2])).view(x.shape[0], x.shape[1], -1)
+        output = B_untied[i](x)
     bfly_end = time.perf_counter()
-    bfly_time = bfly_end - bfly_start
-    print(bfly_time)
+    bfly_time_eval = bfly_end - bfly_start
+    print(f'Butterfly Inference Forward: {bfly_time_eval}')
 
-    # if verbose:
-    #     print(f'Dim: {in_, out_} Batch Size: {batch_size}: {bfly_time}s')
+    output = L[-1](x)
+    gemm_start = time.perf_counter()
+    for i in range(nsteps):
+        output = L[i](x)
+    gemm_end = time.perf_counter()
+    gemm_time = gemm_end - gemm_start
+    print(f'Linear Forward: {gemm_time}')
 
-    # gemm_start = time.perf_counter()
-    # for i in range(nsteps):
-    #     output = L[i](x)
-    # gemm_end = time.perf_counter()
-    # gemm_time = gemm_end - gemm_start
+    print(f'Dim: {in_, out_} Batch Size: {batch_size} Speedup: {gemm_time / bfly_time_eval}x')
 
-    # if verbose:
-    #     print(f'Gemm forward: {gemm_time}s')
-
-    # print(f'Dim: {in_, out_} Batch Size: {batch_size} Speedup: {gemm_time / bfly_time}x')
-
-# without python overhead
-def run_raw(in_, out_, batch_size, verbose=False, seed=1234):
-    torch.manual_seed(seed)
+# call functions directly
+def run_raw(in_, out_, batch_size):
     L = [torch.nn.Linear(in_, out_, bias=False) for _ in range(nsteps)]
     weights = [i.weight.t() for i in L]
-    # sequence len
     x = torch.randn(batch_size, in_, requires_grad=False)
-    x_torch = torch.randn(batch_size, 1, in_, requires_grad=False)
     x_stack = x.unsqueeze(1).expand((batch_size, max(1, out_//in_), in_))
     B_untied = [Butterfly(in_, out_, bias=False, tied_weight=False) for _ in range(nsteps)]
     twiddle_untied = [B_untied[i].twiddle for i in range(nsteps)]
 
-    print("basic")
     bfly_start = time.perf_counter()
     for i in range(nsteps):
-        output = butterfly_mult_untied(twiddle_untied[i], x_stack, True, True)
+        output = butterfly_multiply_untied(twiddle_untied[i], x_stack, True, False)
     bfly_end = time.perf_counter()
-    bfly_time = bfly_end - bfly_start
-    print(f'Dim: {in_, out_} Batch Size: {batch_size}: {bfly_time}s')
+    bfly_time_train = bfly_end - bfly_start
+    print(f'Butterfly Training Forward: {bfly_time_train}')
 
-    print("optimized")
     bfly_start = time.perf_counter()
     for i in range(nsteps):
-        output = butterfly_mult_untied(twiddle_untied[i], x_stack, True, False)
+        output = butterfly_multiply_untied_eval(twiddle_untied[i], x_stack, True)
     bfly_end = time.perf_counter()
-    bfly_time = bfly_end - bfly_start
-    print(f'Dim: {in_, out_} Batch Size: {batch_size}: {bfly_time}s')
-
-    # if batch_size >= 4:
-    #     bfly_start = time.perf_counter()
-    #     for i in range(nsteps):
-    #         output = butterfly_multiply_untied_batch(twiddle_untied[i], x_stack, True)
-    #     bfly_end = time.perf_counter()
-    #     bfly_time = bfly_end - bfly_start
-    #     if verbose:
-    #         print(f'\nButterfly mult untied eval forward: {bfly_time}s')
-    # else:
-    #     bfly_start = time.perf_counter()
-    #     for i in range(nsteps):
-    #         output = butterfly_multiply_untied_eval(twiddle_untied[i], x_stack, True)
-    #     bfly_end = time.perf_counter()
-    #     bfly_time = bfly_end - bfly_start
-    #     if verbose:
-    #         print(f'\nButterfly mult untied eval forward: {bfly_time}s')
+    bfly_time_eval = bfly_end - bfly_start
+    print(f'Butterfly Inference Forward: {bfly_time_eval}')
 
     gemm_start = time.perf_counter()
     for i in range(nsteps):
-        output = x_torch.matmul(weights[i])
+        output = x.matmul(weights[i])
     gemm_end = time.perf_counter()
     gemm_time = gemm_end - gemm_start
-    if verbose:
-        print(f'Gemm forward: {gemm_time}s')
+    print(f'Linear Forward: {gemm_time}')
 
-    # print(f'Dim: {in_, out_} Batch Size: {batch_size}')
-    print(f'Speedup: {gemm_time / bfly_time}x')
+    print(f'Dim: {in_, out_} Batch Size: {batch_size} Speedup: {gemm_time / bfly_time_eval}x')
 
-# run(512, 512, 16, verbose=True)
-# run(512, 1024, 16, verbose=True)
-# run(1024, 512, 16, verbose=True)
-# run(512, 512, 1, verbose=True)
-# run(512, 1024, 1, verbose=True)
-# run(1024, 512, 1, verbose=True)
+print("Call functions with python class")
+run(512, 512, 16)
+run(512, 1024, 16)
+run(1024, 512, 16)
+run(512, 512, 1)
+run(512, 1024, 1)
+run(1024, 512, 1)
 
-# print("Call profile functions directly")
-# run_raw(512, 512, 16, verbose=True)
-# run_raw(512, 1024, 16, verbose=True)
-# run_raw(1024, 512, 16, verbose=True)
-# run_raw(512, 512, 1, verbose=True)
-# run_raw(1024, 1024, 1, verbose=True)
-# run_raw(512, 1024, 1, verbose=True)
-run_raw(1024, 512, 1, verbose=True)
+print("\nCall functions directly")
+run_raw(512, 512, 16)
+run_raw(512, 1024, 16)
+run_raw(1024, 512, 16)
+run_raw(512, 512, 1)
+run_raw(512, 1024, 1)
+run_raw(1024, 512, 1)

--- a/butterfly/benchmark_linear.py
+++ b/butterfly/benchmark_linear.py
@@ -6,38 +6,123 @@ import torch
 
 from butterfly import Butterfly
 from butterfly.butterfly_multiply import butterfly_mult, butterfly_mult_untied, butterfly_mult_untied_svd, butterfly_mult_factors, butterfly_mult_inplace
-from factor_multiply import butterfly_multiply_untied_batch
+from factor_multiply import butterfly_multiply_untied_batch, butterfly_multiply_untied_eval
 
 # single threaded inference
 torch.set_num_threads(1)
 
 import time
-nsteps = 1000
+nsteps = 2000
 
-batch_size = 16
-n = 512
-# create multiple models so the weights aren't already loaded in the cache
-L = [torch.nn.Linear(n, n, bias=False) for _ in range(nsteps)]
-x = torch.randn(batch_size, n, requires_grad=True)
-B_untied = [Butterfly(n, n, bias=False, tied_weight=False) for _ in range(nsteps)]
-twiddle_untied = [B_untied[i].twiddle for i in range(nsteps)]
+# batch_size = 22
+# in_ = 512
+# out_ = 512
 
-grad = torch.randn_like(x)
+def run(in_, out_, batch_size, verbose=False):
+    # create multiple models so the weights aren't already loaded in the cache
+    L = [torch.nn.Linear(in_, out_, bias=False) for _ in range(nsteps)]
+    # sequence length
+    x = torch.randn(batch_size, 1, in_, requires_grad=False)
+    B_untied = [Butterfly(in_, out_, bias=False, tied_weight=False) for _ in range(nsteps)]
+    twiddle_untied = [B_untied[i].twiddle for i in range(nsteps)]
 
-start = time.perf_counter()
-for i in range(nsteps):
-    output = butterfly_mult_untied(twiddle_untied[i], x.unsqueeze(1))
-end = time.perf_counter()
-print(f'Butterfly mult untied forward: {end - start}s')
+    bfly_start = time.perf_counter()
+    for i in range(nsteps):
+        output = B_untied[i](x.contiguous().view(-1, x.shape[2])).view(x.shape[0], x.shape[1], -1)
+    bfly_end = time.perf_counter()
+    bfly_time = bfly_end - bfly_start
+    print(bfly_time)
 
-start = time.perf_counter()
-for i in range(nsteps):
-    output = butterfly_multiply_untied_batch(twiddle_untied[i], x.unsqueeze(1), True)
-end = time.perf_counter()
-print(f'Butterfly mult untied batch forward: {end - start}s')
+    B_untied = [i.eval() for i in B_untied]
+    bfly_start = time.perf_counter()
+    for i in range(nsteps):
+        output = B_untied[i](x.contiguous().view(-1, x.shape[2])).view(x.shape[0], x.shape[1], -1)
+    bfly_end = time.perf_counter()
+    bfly_time = bfly_end - bfly_start
+    print(bfly_time)
 
-start = time.perf_counter()
-for i in range(nsteps):
-    output = L[i](x)
-end = time.perf_counter()
-print(f'Gemm forward: {end - start}s')
+    # if verbose:
+    #     print(f'Dim: {in_, out_} Batch Size: {batch_size}: {bfly_time}s')
+
+    # gemm_start = time.perf_counter()
+    # for i in range(nsteps):
+    #     output = L[i](x)
+    # gemm_end = time.perf_counter()
+    # gemm_time = gemm_end - gemm_start
+
+    # if verbose:
+    #     print(f'Gemm forward: {gemm_time}s')
+
+    # print(f'Dim: {in_, out_} Batch Size: {batch_size} Speedup: {gemm_time / bfly_time}x')
+
+# without python overhead
+def run_raw(in_, out_, batch_size, verbose=False, seed=1234):
+    torch.manual_seed(seed)
+    L = [torch.nn.Linear(in_, out_, bias=False) for _ in range(nsteps)]
+    weights = [i.weight.t() for i in L]
+    # sequence len
+    x = torch.randn(batch_size, in_, requires_grad=False)
+    x_torch = torch.randn(batch_size, 1, in_, requires_grad=False)
+    x_stack = x.unsqueeze(1).expand((batch_size, max(1, out_//in_), in_))
+    B_untied = [Butterfly(in_, out_, bias=False, tied_weight=False) for _ in range(nsteps)]
+    twiddle_untied = [B_untied[i].twiddle for i in range(nsteps)]
+
+    print("basic")
+    bfly_start = time.perf_counter()
+    for i in range(nsteps):
+        output = butterfly_mult_untied(twiddle_untied[i], x_stack, True, True)
+    bfly_end = time.perf_counter()
+    bfly_time = bfly_end - bfly_start
+    print(f'Dim: {in_, out_} Batch Size: {batch_size}: {bfly_time}s')
+
+    print("optimized")
+    bfly_start = time.perf_counter()
+    for i in range(nsteps):
+        output = butterfly_mult_untied(twiddle_untied[i], x_stack, True, False)
+    bfly_end = time.perf_counter()
+    bfly_time = bfly_end - bfly_start
+    print(f'Dim: {in_, out_} Batch Size: {batch_size}: {bfly_time}s')
+
+    # if batch_size >= 4:
+    #     bfly_start = time.perf_counter()
+    #     for i in range(nsteps):
+    #         output = butterfly_multiply_untied_batch(twiddle_untied[i], x_stack, True)
+    #     bfly_end = time.perf_counter()
+    #     bfly_time = bfly_end - bfly_start
+    #     if verbose:
+    #         print(f'\nButterfly mult untied eval forward: {bfly_time}s')
+    # else:
+    #     bfly_start = time.perf_counter()
+    #     for i in range(nsteps):
+    #         output = butterfly_multiply_untied_eval(twiddle_untied[i], x_stack, True)
+    #     bfly_end = time.perf_counter()
+    #     bfly_time = bfly_end - bfly_start
+    #     if verbose:
+    #         print(f'\nButterfly mult untied eval forward: {bfly_time}s')
+
+    gemm_start = time.perf_counter()
+    for i in range(nsteps):
+        output = x_torch.matmul(weights[i])
+    gemm_end = time.perf_counter()
+    gemm_time = gemm_end - gemm_start
+    if verbose:
+        print(f'Gemm forward: {gemm_time}s')
+
+    # print(f'Dim: {in_, out_} Batch Size: {batch_size}')
+    print(f'Speedup: {gemm_time / bfly_time}x')
+
+# run(512, 512, 16, verbose=True)
+# run(512, 1024, 16, verbose=True)
+# run(1024, 512, 16, verbose=True)
+# run(512, 512, 1, verbose=True)
+# run(512, 1024, 1, verbose=True)
+# run(1024, 512, 1, verbose=True)
+
+# print("Call profile functions directly")
+# run_raw(512, 512, 16, verbose=True)
+# run_raw(512, 1024, 16, verbose=True)
+# run_raw(1024, 512, 16, verbose=True)
+# run_raw(512, 512, 1, verbose=True)
+# run_raw(1024, 1024, 1, verbose=True)
+# run_raw(512, 1024, 1, verbose=True)
+run_raw(1024, 512, 1, verbose=True)

--- a/butterfly/butterfly.py
+++ b/butterfly/butterfly.py
@@ -107,12 +107,14 @@ class Butterfly(nn.Module):
                                dim=-1 if not self.complex else -2)
         output = output.unsqueeze(1).expand((batch, self.nstack, self.in_size_extended) + (() if not self.complex else (2, )))
         if self.param == 'regular':
-            output = butterfly_mult(self.twiddle, output, self.increasing_stride) if self.tied_weight else butterfly_mult_untied(self.twiddle, output, self.increasing_stride)
+            output = butterfly_mult(self.twiddle, output, self.increasing_stride) if self.tied_weight else butterfly_mult_untied(
+                    self.twiddle, output, self.increasing_stride, self.training)
         elif self.param == 'ortho':
             c, s = torch.cos(self.twiddle), torch.sin(self.twiddle)
             twiddle = torch.stack((torch.stack((c, -s), dim=-1),
                                    torch.stack((s, c), dim=-1)), dim=-2)
-            output = butterfly_mult(twiddle, output, self.increasing_stride) if self.tied_weight else butterfly_mult_untied(twiddle, output, self.increasing_stride)
+            output = butterfly_mult(twiddle, output, self.increasing_stride) if self.tied_weight else butterfly_mult_untied(
+                twiddle, output, self.increasing_stride, self.training)
         elif self.param == 'svd':
             with torch.no_grad():  # Projected SGD
                 self.twiddle[..., 1, :].clamp_(min=1 / self.max_gain_per_factor, max=self.max_gain_per_factor)

--- a/butterfly/butterfly_multiply.py
+++ b/butterfly/butterfly_multiply.py
@@ -17,7 +17,7 @@ try:
     from factor_multiply import butterfly_factor_multiply, butterfly_factor_multiply_backward
     from factor_multiply import butterfly_conv2d, butterfly_conv2d_backward, butterfly_conv2d_forward_backward
     from factor_multiply import butterfly_conv2d_svd, butterfly_conv2d_svd_forward_backward
-    from factor_multiply import butterfly_multiply_untied_batch
+    from factor_multiply import butterfly_multiply_untied_batch, butterfly_multiply_untied_eval
 except:
     use_extension = False
     import warnings
@@ -165,15 +165,17 @@ class ButterflyMultUntied(torch.autograd.Function):
         # use batch vectorization optimization
         if not is_training and batch_size >= 8:
             # determine how many batches to pad to make batches factor of 8 for vectorization
-            batch_pad = 8 - input.size(0) % 8
+            # batch_pad = 8 - input.size(0) % 8
             # zero pad batches
-            input = F.pad(input, pad=(0,0,0,0,0,batch_pad))
+            # input = F.pad(input, pad=(0,0,0,0,0,batch_pad))
             # remove extra padding
-            output = butterfly_multiply_untied_batch(twiddle, input, increasing_stride)[:-batch_pad]
+            output = butterfly_multiply_untied_batch(twiddle, input, increasing_stride)
+        elif not is_training:
+            output = butterfly_multiply_untied_eval(twiddle, input, increasing_stride)
         else:
             output = butterfly_multiply_untied(twiddle, input, increasing_stride, False)
-            ctx.save_for_backward(twiddle, input)
-            ctx._increasing_stride = increasing_stride
+        ctx.save_for_backward(twiddle, input)
+        ctx._increasing_stride = increasing_stride
         return output
 
     @staticmethod

--- a/butterfly/butterfly_multiply.py
+++ b/butterfly/butterfly_multiply.py
@@ -17,7 +17,7 @@ try:
     from factor_multiply import butterfly_factor_multiply, butterfly_factor_multiply_backward
     from factor_multiply import butterfly_conv2d, butterfly_conv2d_backward, butterfly_conv2d_forward_backward
     from factor_multiply import butterfly_conv2d_svd, butterfly_conv2d_svd_forward_backward
-    from factor_multiply import butterfly_multiply_untied_batch, butterfly_multiply_untied_eval
+    from factor_multiply import butterfly_multiply_untied_eval
 except:
     use_extension = False
     import warnings
@@ -161,16 +161,8 @@ class ButterflyMultUntied(torch.autograd.Function):
         Returns:
             output: (batch_size, nstack, n) if real or (batch_size, nstack, n, 2) if complex
         """
-        batch_size = input.size(0)
-        # use batch vectorization optimization
-        if not is_training and batch_size >= 8:
-            # determine how many batches to pad to make batches factor of 8 for vectorization
-            # batch_pad = 8 - input.size(0) % 8
-            # zero pad batches
-            # input = F.pad(input, pad=(0,0,0,0,0,batch_pad))
-            # remove extra padding
-            output = butterfly_multiply_untied_batch(twiddle, input, increasing_stride)
-        elif not is_training:
+        # use optimized code for inference
+        if not is_training:
             output = butterfly_multiply_untied_eval(twiddle, input, increasing_stride)
         else:
             output = butterfly_multiply_untied(twiddle, input, increasing_stride, False)

--- a/butterfly/factor_multiply/factor_multiply.cpp
+++ b/butterfly/factor_multiply/factor_multiply.cpp
@@ -62,6 +62,17 @@ static inline std::pair<scalar_t, scalar_t> mult2x2(scalar_t a, scalar_t b,
                                                     scalar_t x, scalar_t y) {
   return std::make_pair(a * x + b * y, c * x + d * y);
 }
+typedef union {
+    __m256 m;
+    float v[8];
+} __m256_t;
+
+void print_m256(__m256 a){
+    __m256_t t;
+    t.m = a;
+    std::cout << t.v[0] << " " << t.v[1] << " " << t.v[2] << " " << t.v[3]
+      << " " << t.v[4] << " " << t.v[5] <<  " " << t.v[6] << " " <<  t.v[7] << "\n";
+}
 
 at::Tensor butterfly_factor_multiply(const at::Tensor& twiddle, const at::Tensor& input) {
   /* Parameters:
@@ -717,6 +728,254 @@ at::Tensor butterfly_multiply_untied(const at::Tensor& twiddle, const at::Tensor
   return return_intermediates ? output : output[-1];
 }
 
+void butterfly_multiply_untied_vector(const float* twiddle_data, float* output_data, const int log_n,
+  const int n, const int nstack, const int batch_size, bool increasing_stride) {
+    // supports strides >= 8 and 1 << 3 = 8 -> idx starts at 3
+    for (int64_t idx = 3; idx <= log_n - 1; ++idx) {
+      int64_t log_stride = increasing_stride ? idx : (log_n - 1 - idx + 3);
+      int64_t stride = 1 << log_stride;
+      for (int64_t b = 0; b < batch_size; ++b) {
+        for (int64_t s = 0; s < nstack; ++s) {
+          // manage 8 twiddles at a time
+          for (int64_t i = 0; i < n / 2; i+=8) {
+            int64_t low_order_bit = i % stride;
+            int64_t pos = 2 * (i - low_order_bit) + low_order_bit;
+            // load in twiddles
+            // shape: (nstack, log n, n/2, 2, 2) requires gather instructions
+            int twiddle_idx = s*(log_n*n/2*4) + log_stride*(n/2*4) + i*4;
+            __m256i vindex = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0); // stride 4
+            // 4 for byte offset (i.e. floats = 4 bytes)
+            __m256 mmtwid_00 = _mm256_i32gather_ps(&twiddle_data[twiddle_idx], vindex, 4);
+            __m256 mmtwid_01 = _mm256_i32gather_ps(&twiddle_data[twiddle_idx+1], vindex, 4);
+            __m256 mmtwid_10 = _mm256_i32gather_ps(&twiddle_data[twiddle_idx+2], vindex, 4);
+            __m256 mmtwid_11 = _mm256_i32gather_ps(&twiddle_data[twiddle_idx+3], vindex, 4);
+            // load in input values -- because stride >= 8, we can assume values are contiguous
+            // shape: (batch_size, nstack, n)
+            int wide_idx_0 = b * (nstack * n) + s * n + pos;
+            int wide_idx_1 = b * (nstack * n) + s * n + pos + stride;
+            __m256 mminput_0 = _mm256_loadu_ps(&output_data[wide_idx_0]);
+            __m256 mminput_1 = _mm256_loadu_ps(&output_data[wide_idx_1]);
+            // 4 vector multiplies and two adds
+            __m256 sum1 = _mm256_fmadd_ps(mminput_0, mmtwid_00, _mm256_mul_ps(mminput_1, mmtwid_01));
+            __m256 sum2 = _mm256_fmadd_ps(mminput_0, mmtwid_10, _mm256_mul_ps(mminput_1, mmtwid_11));
+            // write back out contiguously
+            _mm256_storeu_ps(&output_data[wide_idx_0], sum1);
+            _mm256_storeu_ps(&output_data[wide_idx_1], sum2);
+          }
+        }
+      }
+    }
+}
+
+template <typename scalar_t>
+void butterfly_multiply_untied_scalar(const at::TensorAccessor<scalar_t, 5> twiddle_a,
+  at::TensorAccessor<scalar_t, 3> output_a, const int log_n,
+  const int n, const int nstack, const int batch_size, bool increasing_stride){
+    for (int64_t idx = 0; idx <= log_n - 1; ++idx) {
+      int64_t log_stride = increasing_stride ? idx : (log_n - 1 - idx);
+      int64_t stride = 1 << log_stride;
+      for (int64_t b = 0; b < batch_size; ++b) {
+        for (int64_t s = 0; s < nstack; ++s) {
+          for (int64_t i = 0; i < n / 2; ++i) {
+            int64_t low_order_bit = i % stride;
+            int64_t pos = 2 * (i - low_order_bit) + low_order_bit;
+            const scalar_t twiddle_val[2][2] = {{twiddle_a[s][log_stride][i][0][0], twiddle_a[s][log_stride][i][0][1]},
+                                                {twiddle_a[s][log_stride][i][1][0], twiddle_a[s][log_stride][i][1][1]}};
+            const scalar_t input_val[2] = {output_a[b][s][pos], output_a[b][s][pos + stride]};
+            output_a[b][s][pos] = twiddle_val[0][0] * input_val[0] + twiddle_val[0][1] * input_val[1];
+            output_a[b][s][pos + stride] = twiddle_val[1][0] * input_val[0] + twiddle_val[1][1] * input_val[1];
+          }
+        }
+      }
+    }
+}
+
+at::Tensor butterfly_multiply_untied_eval(const at::Tensor& twiddle, const at::Tensor& input, bool increasing_stride) {
+  /* Parameters:
+         twiddle: (nstack, log n, n/2, 2, 2)
+         input: (batch_size, nstack, n)
+         increasing_stride: whether to multiply with increasing stride (e.g. 1, 2, ..., n/2) or
+             decreasing stride (e.g., n/2, n/4, ..., 1).
+             Note that this only changes the order of multiplication, not how twiddle is stored.
+             In other words, twiddle[@log_stride] always stores the twiddle for @stride.
+     Returns:
+        output: (batch_size, nstack, n)
+  */
+  const auto batch_size = input.size(0);
+  const auto nstack = input.size(1);
+  const auto n = input.size(2);
+  const int log_n = int(log2((double) n));
+  AT_CHECK((twiddle.dim() == 5 && input.dim() == 3) || (twiddle.dim() == 6 && input.dim() == 4),
+           "butterfly_multiply_untied: twiddle and input must have dimension 5,3 or 6,4");
+  CHECK_DEVICE(twiddle);
+  CHECK_DEVICE(input);
+  AT_CHECK(twiddle.device() == input.device(), "device of twiddle (", twiddle.device(), ") must match device of input (", input.device(), ")");
+  AT_CHECK(twiddle.size(0) == nstack && twiddle.size(1) == log_n && twiddle.size(2) == n / 2 && twiddle.size(3) == 2 && twiddle.size(4) == 2,
+           "butterfly_multiply_untied: twiddle must have shape (nstack, log n, n/2, 2, 2) or (nstack, log n, n/2, 2, 2, 2)");
+  auto output = input.clone();
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "butterfly_multiply_untied", [&] {
+    const auto twiddle_a = twiddle.accessor<scalar_t, 5>();
+    const float* twiddle_data = twiddle.data<float>();
+    auto output_a = output.accessor<scalar_t, 3>();
+    float* output_data = output.data<float>();
+    if (increasing_stride){
+      // do small strides first
+      butterfly_multiply_untied_scalar<scalar_t>(twiddle_a, output_a, 3 /*log_n*/, n, nstack, batch_size, increasing_stride);
+      butterfly_multiply_untied_vector(twiddle_data, output_data, log_n, n, nstack, batch_size, increasing_stride);
+    } else {
+      // do large strides first
+      butterfly_multiply_untied_vector(twiddle_data, output_data, log_n, n, nstack, batch_size, increasing_stride);
+      butterfly_multiply_untied_scalar<scalar_t>(twiddle_a, output_a, 3 /*log_n*/, n, nstack, batch_size, increasing_stride);
+    }
+  });
+  return output;
+}
+
+// at::Tensor butterfly_multiply_untied_eval(const at::Tensor& twiddle, const at::Tensor& input, bool increasing_stride) {
+//   /* Parameters:
+//          twiddle: (nstack, log n, n/2, 2, 2) if real or (nstack, log n, n/2, 2, 2, 2) if complex
+//          input: (batch_size, nstack, n) if real or (batch_size, nstack, n, 2) if complex
+//          increasing_stride: whether to multiply with increasing stride (e.g. 1, 2, ..., n/2) or
+//              decreasing stride (e.g., n/2, n/4, ..., 1).
+//              Note that this only changes the order of multiplication, not how twiddle is stored.
+//              In other words, twiddle[@log_stride] always stores the twiddle for @stride.
+//          return_intermediates: whether to return just the output (i.e. computed in-place) or output
+//              and intermediate values for backward pass.
+//      Returns:
+//          if return_intermediates:
+//              output + intermediate values for backward pass: (log n + 1, batch_size, nstack, n) if real or (log n + 1, batch_size, nstack, n, 2) if complex
+//          else:
+//              output: (batch_size, nstack, n) if real or (batch_size, nstack, n, 2) if complex
+//   */
+//   const auto batch_size = input.size(0);
+//   const auto nstack = input.size(1);
+//   const auto n = input.size(2);
+//   const int log_n = int(log2((double) n));
+//   AT_CHECK((twiddle.dim() == 5 && input.dim() == 3) || (twiddle.dim() == 6 && input.dim() == 4),
+//            "butterfly_multiply_untied: twiddle and input must have dimension 5,3 or 6,4");
+//   CHECK_DEVICE(twiddle);
+//   CHECK_DEVICE(input);
+//   AT_CHECK(twiddle.device() == input.device(), "device of twiddle (", twiddle.device(), ") must match device of input (", input.device(), ")");
+//   AT_CHECK(twiddle.size(0) == nstack && twiddle.size(1) == log_n && twiddle.size(2) == n / 2 && twiddle.size(3) == 2 && twiddle.size(4) == 2,
+//            "butterfly_multiply_untied: twiddle must have shape (nstack, log n, n/2, 2, 2) or (nstack, log n, n/2, 2, 2, 2)");
+//   auto output = input.clone();
+//   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "butterfly_multiply_untied", [&] {
+//   const auto twiddle_a = twiddle.accessor<scalar_t, 5>();
+//   auto output_a = output.accessor<scalar_t, 3>();
+//   for (int64_t idx = 0; idx <= log_n - 1; ++idx) {
+//     int64_t log_stride = increasing_stride ? idx : (log_n - 1 - idx);
+//     int64_t stride = 1 << log_stride;
+//     for (int64_t b = 0; b < batch_size; ++b) {
+//       for (int64_t s = 0; s < nstack; ++s) {
+//         for (int64_t i = 0; i < n / 2; ++i) {
+//           int64_t low_order_bit = i % stride;
+//           int64_t pos = 2 * (i - low_order_bit) + low_order_bit;
+//           const scalar_t twiddle_val[2][2] = {{twiddle_a[s][log_stride][i][0][0], twiddle_a[s][log_stride][i][0][1]},
+//                                               {twiddle_a[s][log_stride][i][1][0], twiddle_a[s][log_stride][i][1][1]}};
+//           const scalar_t input_val[2] = {output_a[b][s][pos], output_a[b][s][pos + stride]};
+//           output_a[b][s][pos] = twiddle_val[0][0] * input_val[0] + twiddle_val[0][1] * input_val[1];
+//           output_a[b][s][pos + stride] = twiddle_val[1][0] * input_val[0] + twiddle_val[1][1] * input_val[1];
+//         }
+//       }
+//     }
+//   }
+//   });
+//   return output;
+// }
+
+// at::Tensor butterfly_multiply_untied_eval(const at::Tensor& twiddle, const at::Tensor& input, bool increasing_stride) {
+//   /* Parameters:
+//          twiddle: (nstack, log n, n/2, 2, 2) if real or (nstack, log n, n/2, 2, 2, 2) if complex
+//          input: (batch_size, nstack, n)
+//          increasing_stride: whether to multiply with increasing stride (e.g. 1, 2, ..., n/2) or
+//              decreasing stride (e.g., n/2, n/4, ..., 1).
+//              Note that this only changes the order of multiplication, not how twiddle is stored.
+//              In other words, twiddle[@log_stride] always stores the twiddle for @stride.
+//      Returns:
+//         output: (batch_size, nstack, n)
+//   */
+//   const auto batch_size = input.size(0);
+//   const auto nstack = input.size(1);
+//   const auto n = input.size(2);
+//   const int log_n = int(log2((double) n));
+//   AT_CHECK((twiddle.dim() == 5 && input.dim() == 3),
+//            "butterfly_multiply_untied_eval: twiddle and input must have dimension 5,3");
+//   CHECK_DEVICE(twiddle);
+//   CHECK_DEVICE(input);
+//   AT_CHECK(twiddle.device() == input.device(), "device of twiddle (", twiddle.device(), ") must match device of input (", input.device(), ")");
+//   AT_CHECK(twiddle.size(0) == nstack && twiddle.size(1) == log_n && twiddle.size(2) == n / 2 && twiddle.size(3) == 2 && twiddle.size(4) == 2,
+//            "butterfly_multiply_untied_eval: twiddle must have shape (nstack, log n, n/2, 2, 2)");
+//   auto output = input.clone();
+
+//   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "butterfly_multiply_untied_eval", [&] {
+//     float* twiddle_data = twiddle.data<float>();
+//     const auto twiddle_a = twiddle.accessor<scalar_t, 5>();
+//     auto output_a = output.accessor<scalar_t, 3>();
+//     for (int64_t idx = 0; idx <= log_n - 1; ++idx) {
+//       int64_t log_stride = increasing_stride ? idx : (log_n - 1 - idx);
+//       int64_t stride = 1 << log_stride;
+//       // std::cout << stride << "\n";
+//       int64_t ii;
+//       for (ii = 0; ii < n/2; ii+=16) {
+//         for (int64_t b = 0; b < batch_size; ++b) {
+//           for (int64_t s = 0; s < nstack; ++s) {
+//             for (int64_t i = ii; i < ii+16; i+=1) {
+//               // __builtin_prefetch(&twiddle_data[(s * log_n * n/2 * 2 * 2) + (log_stride * n/2 * 2 * 2) + ((i+1) * 2 * 2)]);
+//               // _mm_prefetch(&twiddle_data[(s * log_n * n/2 * 2 * 2) + (log_stride * n/2 * 2 * 2) + ((i+1) * 2 * 2)], _MM_HINT_T0);
+//               // _mm_prefetch(&twiddle_data[(s * log_n * n/2 * 2 * 2) + (log_stride * n/2 * 2 * 2) + ((i+1) * 2 * 2) * 4], _MM_HINT_T0);
+//               int64_t low_order_bit = i % stride;
+//               int64_t pos = 2 * (i - low_order_bit) + low_order_bit;
+//               const scalar_t twiddle_val[2][2] = {{twiddle_a[s][log_stride][i][0][0], twiddle_a[s][log_stride][i][0][1]},
+//                                                   {twiddle_a[s][log_stride][i][1][0], twiddle_a[s][log_stride][i][1][1]}};
+//               const scalar_t input_val[2] = {output_a[b][s][pos], output_a[b][s][pos + stride]};
+//               output_a[b][s][pos] = twiddle_val[0][0] * input_val[0] + twiddle_val[0][1] * input_val[1];
+//               output_a[b][s][pos + stride] = twiddle_val[1][0] * input_val[0] + twiddle_val[1][1] * input_val[1];
+//             }
+//           }
+//         }
+//       }
+
+
+//       //     for (int64_t i = 0; i < n / 2; i+=4) {
+//       //       __builtin_prefetch(&twiddle_data[(s * log_n * n/2 * 2 * 2) + (log_stride * n/2 * 2 * 2) + ((i+1) * 2 * 2)]);
+//       //       int64_t low_order_bit = i % stride;
+//       //       int64_t pos = 2 * (i - low_order_bit) + low_order_bit;
+//       //       // unroll the loop to hide memory latency and loop overhead
+//       //       // access twiddle by pointer since it's stored contiguously
+//       //       int twiddle_base_idx = (s * log_n * n/2 * 2 * 2) + (log_stride * n/2 * 2 * 2) + (i * 2 * 2);
+//       //       float* twiddle_0 = &twiddle_data[twiddle_base_idx];
+//       //       const scalar_t input_val_0[2] = {output_a[b][s][pos], output_a[b][s][pos + stride]};
+//       //       output_a[b][s][pos] = *twiddle_0 * input_val_0[0] + *(twiddle_0+1) * input_val_0[1];
+//       //       output_a[b][s][pos + stride] = *(twiddle_0+2) * input_val_0[0] + *(twiddle_0+3) * input_val_0[1];
+
+//       //       float* twiddle_1 = &twiddle_data[twiddle_base_idx+4];
+//       //       int64_t low_order_bit_1 = (i+1) % stride;
+//       //       int64_t pos_1 = 2 * ((i+1) - low_order_bit_1) + low_order_bit_1;
+//       //       const scalar_t input_val_1[2] = {output_a[b][s][pos_1], output_a[b][s][pos_1 + stride]};
+//       //       output_a[b][s][pos_1] = *twiddle_1 * input_val_1[0] + *(twiddle_1+1) * input_val_1[1];
+//       //       output_a[b][s][pos_1 + stride] = *(twiddle_1+2) * input_val_1[0] + *(twiddle_1+3) * input_val_1[1];
+
+//       //       float* twiddle_2 = &twiddle_data[twiddle_base_idx+8];
+//       //       int64_t low_order_bit_2 = (i+2) % stride;
+//       //       int64_t pos_2 = 2 * ((i+2) - low_order_bit_2) + low_order_bit_2;
+//       //       const scalar_t input_val_2[2] = {output_a[b][s][pos_2], output_a[b][s][pos_2 + stride]};
+//       //       output_a[b][s][pos_2] = *twiddle_2 * input_val_2[0] + *(twiddle_2+1) * input_val_2[1];
+//       //       output_a[b][s][pos_2 + stride] = *(twiddle_2+2) * input_val_2[0] + *(twiddle_2+3) * input_val_2[1];
+
+//       //       float* twiddle_3 = &twiddle_data[twiddle_base_idx+12];
+//       //       int64_t low_order_bit_3 = (i+3) % stride;
+//       //       int64_t pos_3 = 2 * ((i+3) - low_order_bit_3) + low_order_bit_3;
+//       //       const scalar_t input_val_3[2] = {output_a[b][s][pos_3], output_a[b][s][pos_3 + stride]};
+//       //       output_a[b][s][pos_3] = *twiddle_3 * input_val_3[0] + *(twiddle_3+1) * input_val_3[1];
+//       //       output_a[b][s][pos_3 + stride] = *(twiddle_3+2) * input_val_3[0] + *(twiddle_3+3) * input_val_3[1];
+//       //     }
+//       //   }
+//       // }
+//     }
+//   });
+//   return output;
+// }
+
 at::Tensor butterfly_multiply_untied_batch(const at::Tensor& twiddle, const at::Tensor& input, bool increasing_stride) {
   /* Vectorizes over the batch for inference. Useful for batch sizes >= 8. Only supports reals, 32-bit input, and cpus.
     Parameters:
@@ -739,13 +998,15 @@ at::Tensor butterfly_multiply_untied_batch(const at::Tensor& twiddle, const at::
     ") must match device of input (", input.device(), ")");
   AT_CHECK((twiddle.dim() == 5 && input.dim() == 3),
            "butterfly_multiply_untied: twiddle and input must have dimension 5,3");
-  AT_CHECK((batch_size % 8 == 0), "Only multiples of 8 currently supported for batch size. Padding can be used.");
+  // AT_CHECK((batch_size % 8 == 0), "Only multiples of 8 currently supported for batch size. Padding can be used.");
   AT_CHECK(twiddle.size(0) == nstack && twiddle.size(1) == log_n && twiddle.size(2) == n / 2 && twiddle.size(3) == 2 && twiddle.size(4) == 2,
            "butterfly_multiply_untied: twiddle must have shape (nstack, log n, n/2, 2, 2)");
   auto output = input.permute({1,2,0}).contiguous().clone();
+  int max_vector_batch = batch_size / 8 * 8;
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "butterfly_multiply_untied_batch", [&] {
     const auto twiddle_a = twiddle.accessor<scalar_t, 5>();
     float* output_data = output.data<float>();
+    auto output_a = output.accessor<scalar_t, 3>();
     for (int64_t idx = 0; idx <= log_n - 1; ++idx) {
       int64_t log_stride = increasing_stride ? idx : (log_n - 1 - idx);
       int64_t stride = 1 << log_stride;
@@ -758,8 +1019,13 @@ at::Tensor butterfly_multiply_untied_batch(const at::Tensor& twiddle, const at::
           __m256 mmtwid_11 = _mm256_set1_ps(twiddle_a[s][log_stride][i][1][1]);
           int64_t low_order_bit = i % stride;
           int64_t pos = 2 * (i - low_order_bit) + low_order_bit;
-          // TODO: try blocking if batch_sizes are large to not mess up cache
-          for (int64_t b = 0; b < batch_size; b += 8) {
+          int64_t b;
+          for (b = 0; b < max_vector_batch; b += 8) {
+            // _mm_prefetch(&output_data[ (s) * (batch_size * n) + ((pos) * batch_size + b+8)], _MM_HINT_T0);
+            // _mm_prefetch(&output_data[(s) * (batch_size * n) + ((pos + stride) * batch_size + b+8)], _MM_HINT_T0);
+            // _mm_prefetch(&output_data[ (s) * (batch_size * n) + ((pos) * batch_size + b+12)], _MM_HINT_T0);
+            // _mm_prefetch(&output_data[(s) * (batch_size * n) + ((pos + stride) * batch_size + b+12)], _MM_HINT_T0);
+
             // load 8 values in 256b register -- we assume batches are contiguous at this point
             int wide_idx_0 = (s) * (batch_size * n) + ((pos) * batch_size + b);
             int wide_idx_1 = (s) * (batch_size * n) + ((pos + stride) * batch_size + b);
@@ -771,6 +1037,18 @@ at::Tensor butterfly_multiply_untied_batch(const at::Tensor& twiddle, const at::
             // store 256b register values in place
             _mm256_storeu_ps(&output_data[wide_idx_0], sum1);
             _mm256_storeu_ps(&output_data[wide_idx_1], sum2);
+          }
+          // Deal with the leftover batches individually
+          for (int64_t bb = b; bb < batch_size; bb++) {
+            int64_t low_order_bit = i % stride;
+            int64_t pos = 2 * (i - low_order_bit) + low_order_bit;
+            int wide_idx_0 = (s) * (batch_size * n) + ((pos) * batch_size + bb);
+            int wide_idx_1 = (s) * (batch_size * n) + ((pos + stride) * batch_size + bb);
+            const scalar_t twiddle_val[2][2] = {{twiddle_a[s][log_stride][i][0][0], twiddle_a[s][log_stride][i][0][1]},
+                                                {twiddle_a[s][log_stride][i][1][0], twiddle_a[s][log_stride][i][1][1]}};
+            const scalar_t input_val[2] = { output_data[wide_idx_0], output_data[wide_idx_1]};
+            output_data[wide_idx_0] = twiddle_val[0][0] * input_val[0] + twiddle_val[0][1] * input_val[1];
+            output_data[wide_idx_1] = twiddle_val[1][0] * input_val[0] + twiddle_val[1][1] * input_val[1];
           }
         }
       }
@@ -1748,6 +2026,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("butterfly_multiply_intermediate_backward", &butterfly_multiply_intermediate_backward, "Butterfly factor multiply intermediate backward");
   m.def("butterfly_multiply_untied", &butterfly_multiply_untied, "Butterfly factor multiply untied forward");
   m.def("butterfly_multiply_untied_batch", &butterfly_multiply_untied_batch, "Butterfly factor multiply untied batch forward");
+  m.def("butterfly_multiply_untied_eval", &butterfly_multiply_untied_eval, "Butterfly factor multiply untied eval forward");
   m.def("butterfly_multiply_untied_backward", &butterfly_multiply_untied_backward, "Butterfly factor multiply untied backward");
   m.def("butterfly_multiply_untied_forward_backward", &butterfly_multiply_untied_forward_backward, "Butterfly factor multiply untied forward+backward");
   m.def("butterfly_conv2d", &butterfly_conv2d, "Butterfly conv2d forward");

--- a/butterfly/factor_multiply/setup.py
+++ b/butterfly/factor_multiply/setup.py
@@ -10,7 +10,7 @@ if torch.cuda.is_available() and CUDA_HOME is not None:
             'factor_multiply.cpp',
             'factor_multiply_cuda.cu'
         ],
-        extra_compile_args={'cxx': ['-g', '-march=native'],
+        extra_compile_args={'cxx': ['-g', '-march=native', '-funroll-loops'],
                             # 'nvcc': ['-arch=sm_60', '-O2', '-lineinfo']})
                             'nvcc': ['-O2', '-lineinfo']})
     ext_modules.append(extension)

--- a/cnn/models/butterfly_conv.py
+++ b/cnn/models/butterfly_conv.py
@@ -77,7 +77,7 @@ class ButterflyConv2d(ButterflyBmm):
         h_out = (h + 2 * self.padding[0] - self.dilation[0] * (self.kernel_size[0] - 1) - 1) // self.stride[0] + 1
         w_out = (h + 2 * self.padding[1] - self.dilation[1] * (self.kernel_size[1] - 1) - 1) // self.stride[1] + 1
         if not (self.fused_unfold and self.stride == 1 and self.kernel_size[0] == self.kernel_size[1]
-                and self.padding[0] == self.padding[1] and and self.dilation == (1, 1) and c <= 1024 and input.is_cuda):
+                and self.padding[0] == self.padding[1] and self.dilation == (1, 1) and c <= 1024 and input.is_cuda):
             # unfold input into patches and call batch matrix multiply
             input_patches = F.unfold(input, self.kernel_size, self.dilation, self.padding, self.stride).view(
                 batch, c, self.kernel_size[0] * self.kernel_size[1], h_out * w_out)

--- a/tests/test_butterfly_multiply.py
+++ b/tests/test_butterfly_multiply.py
@@ -15,7 +15,7 @@ from butterfly.butterfly_multiply import butterfly_mult_untied_torch, butterfly_
 from butterfly.butterfly_multiply import butterfly_mult_conv2d_torch, butterfly_mult_conv2d
 from butterfly.butterfly_multiply import butterfly_mult_untied_svd_torch, butterfly_mult_untied_svd
 from butterfly.butterfly_multiply import butterfly_mult_conv2d_svd_torch, butterfly_mult_conv2d_svd
-
+from factor_multiply import butterfly_multiply_untied_batch
 
 class ButterflyMultTest(unittest.TestCase):
 
@@ -79,6 +79,28 @@ class ButterflyMultTest(unittest.TestCase):
                                                        atol=self.atol * (10 if batch_size > 1024 else 1)),
                                         (((d_twiddle - d_twiddle_torch) / d_twiddle_torch).abs().max().item(),
                                          (batch_size, n), device, complex, increasing_stride))
+
+    def test_butterfly_untied_batch(self):
+        for batch_size, n in [(8, 256), (10, 512)]:
+            m = int(math.log2(n))
+            nstack = 2
+            for device in ['cpu']:
+                for complex in [ True]:
+                    for increasing_stride in [True, False]:
+                        scaling = 1 / math.sqrt(2)
+                        twiddle = torch.randn((nstack, m, n // 2, 2, 2), requires_grad=True, device=device) * scaling
+                        input = torch.randn((batch_size, nstack, n), requires_grad=True, device=twiddle.device)
+                        output = butterfly_mult_untied(twiddle, input, increasing_stride, False) # is_training = False
+                        output_torch = butterfly_mult_untied_torch(twiddle, input, increasing_stride)
+                        self.assertTrue(torch.allclose(output, output_torch, rtol=self.rtol, atol=self.atol),
+                                        ((output - output_torch).abs().max().item(), device, complex, increasing_stride))
+
+                        # also call directly in case butterfly_mult_untied gets changed
+                        if batch_size % 8 != 0:
+                            continue
+                        output = butterfly_multiply_untied_batch(twiddle, input, increasing_stride)
+                        self.assertTrue(torch.allclose(output, output_torch, rtol=self.rtol, atol=self.atol),
+                                        ((output - output_torch).abs().max().item(), device, complex, increasing_stride))
 
     def test_butterfly_untied_svd(self):
         for batch_size, n in [(10, 4096), (99, 128)]:  # Test size smaller than 1024

--- a/tests/test_butterfly_multiply.py
+++ b/tests/test_butterfly_multiply.py
@@ -15,7 +15,7 @@ from butterfly.butterfly_multiply import butterfly_mult_untied_torch, butterfly_
 from butterfly.butterfly_multiply import butterfly_mult_conv2d_torch, butterfly_mult_conv2d
 from butterfly.butterfly_multiply import butterfly_mult_untied_svd_torch, butterfly_mult_untied_svd
 from butterfly.butterfly_multiply import butterfly_mult_conv2d_svd_torch, butterfly_mult_conv2d_svd
-from factor_multiply import butterfly_multiply_untied_batch, butterfly_multiply_untied_eval
+from factor_multiply import butterfly_multiply_untied_eval
 
 class ButterflyMultTest(unittest.TestCase):
 
@@ -80,30 +80,8 @@ class ButterflyMultTest(unittest.TestCase):
                                         (((d_twiddle - d_twiddle_torch) / d_twiddle_torch).abs().max().item(),
                                          (batch_size, n), device, complex, increasing_stride))
 
-    def test_butterfly_untied_batch(self):
-        for batch_size, n in [(8, 256), (10, 512)]:
-            m = int(math.log2(n))
-            nstack = 2
-            for device in ['cpu']:
-                for complex in [ True]:
-                    for increasing_stride in [True, False]:
-                        scaling = 1 / math.sqrt(2)
-                        twiddle = torch.randn((nstack, m, n // 2, 2, 2), requires_grad=True, device=device) * scaling
-                        input = torch.randn((batch_size, nstack, n), requires_grad=True, device=twiddle.device)
-                        output = butterfly_mult_untied(twiddle, input, increasing_stride, False) # is_training = False
-                        output_torch = butterfly_mult_untied_torch(twiddle, input, increasing_stride)
-                        self.assertTrue(torch.allclose(output, output_torch, rtol=self.rtol, atol=self.atol),
-                                        ((output - output_torch).abs().max().item(), device, complex, increasing_stride))
-
-                        # also call directly in case butterfly_mult_untied gets changed
-                        if batch_size % 8 != 0:
-                            continue
-                        output = butterfly_multiply_untied_batch(twiddle, input, increasing_stride)
-                        self.assertTrue(torch.allclose(output, output_torch, rtol=self.rtol, atol=self.atol),
-                                        ((output - output_torch).abs().max().item(), device, complex, increasing_stride))
-
     def test_butterfly_untied_eval(self):
-        for batch_size, n in [(1, 256), (2, 512)]:
+        for batch_size, n in [(1, 256), (2, 512), (8, 512), (10, 512)]:
             m = int(math.log2(n))
             nstack = 2
             for device in ['cpu']:

--- a/tests/test_butterfly_multiply.py
+++ b/tests/test_butterfly_multiply.py
@@ -15,7 +15,7 @@ from butterfly.butterfly_multiply import butterfly_mult_untied_torch, butterfly_
 from butterfly.butterfly_multiply import butterfly_mult_conv2d_torch, butterfly_mult_conv2d
 from butterfly.butterfly_multiply import butterfly_mult_untied_svd_torch, butterfly_mult_untied_svd
 from butterfly.butterfly_multiply import butterfly_mult_conv2d_svd_torch, butterfly_mult_conv2d_svd
-from factor_multiply import butterfly_multiply_untied_batch
+from factor_multiply import butterfly_multiply_untied_batch, butterfly_multiply_untied_eval
 
 class ButterflyMultTest(unittest.TestCase):
 
@@ -99,6 +99,21 @@ class ButterflyMultTest(unittest.TestCase):
                         if batch_size % 8 != 0:
                             continue
                         output = butterfly_multiply_untied_batch(twiddle, input, increasing_stride)
+                        self.assertTrue(torch.allclose(output, output_torch, rtol=self.rtol, atol=self.atol),
+                                        ((output - output_torch).abs().max().item(), device, complex, increasing_stride))
+
+    def test_butterfly_untied_eval(self):
+        for batch_size, n in [(1, 256), (2, 512)]:
+            m = int(math.log2(n))
+            nstack = 2
+            for device in ['cpu']:
+                for complex in [ True]:
+                    for increasing_stride in [True, False]:
+                        scaling = 1 / math.sqrt(2)
+                        twiddle = torch.randn((nstack, m, n // 2, 2, 2), requires_grad=True, device=device) * scaling
+                        input = torch.randn((batch_size, nstack, n), requires_grad=True, device=twiddle.device)
+                        output = butterfly_multiply_untied_eval(twiddle, input, increasing_stride)
+                        output_torch = butterfly_mult_untied_torch(twiddle, input, increasing_stride)
                         self.assertTrue(torch.allclose(output, output_torch, rtol=self.rtol, atol=self.atol),
                                         ((output - output_torch).abs().max().item(), device, complex, increasing_stride))
 


### PR DESCRIPTION
I added two optimizations for inference for multiply_untied in a new function called multiply_untied_eval, both opts use avx vectorization so require avx2 to be available and assume we are using floats. 

1. Vectorization over the batch for large batch sizes---the previous code was slower than linear layers with large batch sizes, and this puts us at about 3x faster than a GEMM call for n=512, batch size=16. We use 256b registers so 8 batch values are computed at once. Left over batches are handled individually -- this turned out to be a little faster than calling padding functions in python, but also means there is no benefit if the batch size is less than 8. In order to do this vectorization and have stride=1 for the batches, the input data had to be permuted. 

2. Vectorization over the twiddle factors. This takes the current code and vectorizes it's inner loops, taking advantage of the fact that once the stride >= 8, then we can load 8 contiguous input values at a time (16 if counting total with the stride). This led to just under a 2x speedup over the current multiply untied for n=512, batch size 1. Right now I put these optimizations in the same function and call (1) if batch size is >= 8, and (2) otherwise. This seemed to have the best timing results, and the benchmark script is included. 